### PR TITLE
Illustrating handlers sharing problem and proposing a solution

### DIFF
--- a/src/MethodProxies-Tests/MpMethodProxyTest.class.st
+++ b/src/MethodProxies-Tests/MpMethodProxyTest.class.st
@@ -354,6 +354,26 @@ MpMethodProxyTest >> testSharedHandler [
 	
 ]
 
+{ #category : #tests }
+MpMethodProxyTest >> testSharedHandlerModel [
+	|h1 h2 mp1 mp2 model|
+	h1 := self handlerClass new.
+	h2 := self handlerClass new.
+	
+	mp1 := MpMethodProxy on: #methodOne inClass: MpClassA handler: h1.
+	mp2 := MpMethodProxy on: #methodTwo inClass: MpClassA handler: h2.
+	
+	self assert: h1 proxy identicalTo: mp1.
+	self assert: h2 proxy identicalTo: mp2.
+	
+	model := Object new.
+	h1 model: model.
+	h2 model: model.
+	
+	self assert: h1 model identicalTo: model.
+	self assert: h2 model identicalTo: model
+]
+
 { #category : #'tests - installation' }
 MpMethodProxyTest >> testUninstall [
 

--- a/src/MethodProxies-Tests/MpMethodProxyTest.class.st
+++ b/src/MethodProxies-Tests/MpMethodProxyTest.class.st
@@ -324,6 +324,36 @@ MpMethodProxyTest >> testRecursiveMethodWrapperDoesNotRecurse [
 	self assert: MpMockObject new recursiveMethod equals: 'trapped [original]'.
 ]
 
+{ #category : #tests }
+MpMethodProxyTest >> testSharedHandler [
+	"This test illustrates handler sharing which seems conceptually flawed.
+	We try to share a handler h between two proxies mp1 and mp2.
+	
+	Because handlers and proxies are tied through an inverse relation, setting the handler h to the proxy mp1 
+	automatically sets the proxy mp1 to h.
+	
+	Therefore, h proxy == mp1.
+	
+	However, if just after we create the proxy mp2 and try to share the handler h, the inverse relation will
+	make the proxy of h to become mp2.
+	Then h proxy == mp2.
+	
+	We are effectively sharing h among the two proxies, but actions upon method interception
+	happen in h, who will only ever know the last proxy. 
+	Therefore, when proxy mp1 intercepts a method and calls h, h will be confused because it thinks the interceptions comes from proxy mp2.	"
+	|h mp1 mp2|
+	h := self handlerClass new.
+	
+	mp1 := MpMethodProxy on: #methodOne inClass: MpClassA handler: h.
+	self assert: h proxy identicalTo: mp1.
+	
+	mp2 := MpMethodProxy on: #methodTwo inClass: MpClassA handler: h.
+	
+	self deny: h proxy identicalTo: mp1.
+	self assert: h proxy identicalTo: mp2.
+	
+]
+
 { #category : #'tests - installation' }
 MpMethodProxyTest >> testUninstall [
 

--- a/src/MethodProxies/MpHandler.class.st
+++ b/src/MethodProxies/MpHandler.class.st
@@ -9,10 +9,17 @@ Class {
 	#name : #MpHandler,
 	#superclass : #Object,
 	#instVars : [
-		'proxy'
+		'proxy',
+		'handlerModel'
 	],
 	#category : #MethodProxies
 }
+
+{ #category : #'instance creation' }
+MpHandler class >> on: aModel [
+
+	^ self new model: aModel
+]
 
 { #category : #evaluating }
 MpHandler >> afterExecutionWithReceiver: anObject arguments: anArrayOfObjects returnValue: aReturnValue [
@@ -36,7 +43,32 @@ MpHandler >> beforeExecutionWithReceiver: anObject arguments: anArrayOfObjects [
 MpHandler >> beforeMethod [
 ]
 
-{ #category : #evaluating }
+{ #category : #accessing }
+MpHandler >> handlerModel [
+
+	^ handlerModel ifNil: [ handlerModel := MpHandlerModel new ]
+]
+
+{ #category : #accessing }
+MpHandler >> model [
+
+	^ self handlerModel model
+]
+
+{ #category : #accessing }
+MpHandler >> model: anObject [
+
+	self handlerModel model: anObject
+]
+
+{ #category : #accessing }
+MpHandler >> proxy [
+	^self handlerModel proxy
+
+]
+
+{ #category : #accessing }
 MpHandler >> proxy: aMethodProxy [
-	proxy := aMethodProxy
+	self handlerModel proxy: aMethodProxy
+
 ]

--- a/src/MethodProxies/MpHandlerModel.class.st
+++ b/src/MethodProxies/MpHandlerModel.class.st
@@ -1,0 +1,49 @@
+"
+I am a container object to share models between proxies' handlers.
+MpHandlers objects can share the same model, who each know their proxy. 
+
+I therefore hold:
+- An optionnal model provided by a client. This model is intented to be called from the handler to perform operations upon method call interception.
+- The proxy who owns my handler.
+
+See MpMethodProxyTest>>testSharedHandlerModel
+"
+Class {
+	#name : #MpHandlerModel,
+	#superclass : #Object,
+	#instVars : [
+		'proxy',
+		'model'
+	],
+	#category : #MethodProxies
+}
+
+{ #category : #'instance creation' }
+MpHandlerModel class >> on: aModel [
+
+	^ self new model: aModel
+]
+
+{ #category : #accessing }
+MpHandlerModel >> model [
+
+	^ model
+]
+
+{ #category : #accessing }
+MpHandlerModel >> model: anObject [
+
+	model := anObject
+]
+
+{ #category : #accessing }
+MpHandlerModel >> proxy [
+
+	^ proxy
+]
+
+{ #category : #accessing }
+MpHandlerModel >> proxy: anObject [
+
+	proxy := anObject
+]


### PR DESCRIPTION
The solution includes a simple container class in handlers, intended to share a common object named "model".
That model implements common behavior and shares data to be used upon a proxified method execution.

Naming and implementation are maybe wrong, I'm trying to illustrate my usecase simply and quickly.
