### PR TITLE
Fix handling of non local returns

### DIFF
--- a/src/MethodProxies-Tests/MpAfterCounterHandler.class.st
+++ b/src/MethodProxies-Tests/MpAfterCounterHandler.class.st
@@ -1,0 +1,30 @@
+"
+I am a method proxy handler for testing that increments a counter after the method has been executed.
+I therefore test method exit
+"
+Class {
+	#name : #MpAfterCounterHandler,
+	#superclass : #MpHandler,
+	#instVars : [
+		'count'
+	],
+	#category : #'MethodProxies-Tests'
+}
+
+{ #category : #evaluating }
+MpAfterCounterHandler >> afterMethod [
+
+	count := count + 1
+]
+
+{ #category : #accessing }
+MpAfterCounterHandler >> count [
+	^ count
+]
+
+{ #category : #evaluating }
+MpAfterCounterHandler >> initialize [
+
+	super initialize.
+	count := 0
+]

--- a/src/MethodProxies-Tests/MpClassA.class.st
+++ b/src/MethodProxies-Tests/MpClassA.class.st
@@ -12,6 +12,12 @@ Class {
 	#category : #'MethodProxies-Tests'
 }
 
+{ #category : #accessing }
+MpClassA >> methodAcceptingABlock: aBlock [
+
+	^ aBlock value
+]
+
 { #category : #debugging }
 MpClassA >> methodDelay [
 
@@ -47,6 +53,12 @@ MpClassA >> methodWithArgument: anInteger [
 MpClassA >> methodWithException [
 
 	1/0
+]
+
+{ #category : #accessing }
+MpClassA >> methodWithNonLocalReturn [
+
+	self methodAcceptingABlock: [ ^ self ]
 ]
 
 { #category : #debugging }

--- a/src/MethodProxies-Tests/MpMethodProxyTest.class.st
+++ b/src/MethodProxies-Tests/MpMethodProxyTest.class.st
@@ -423,6 +423,21 @@ MpMethodProxyTest >> testWrapMethodCalledDuringInstallationIsNotIntercepted [
 	self deny: handler called
 ]
 
+{ #category : #'tests - safety' }
+MpMethodProxyTest >> testWrapNonLocalReturns [
+
+	| mp handler |
+	mp := MpMethodProxy
+		      onMethod: MpClassA >> #methodAcceptingABlock:
+		      handler: (handler := MpAfterCounterHandler new).
+
+	self installMethodProxy: mp.
+
+	MpClassA new methodWithNonLocalReturn.
+
+	self assert: handler count equals: 1
+]
+
 { #category : #tests }
 MpMethodProxyTest >> testWrappingTwiceIsPossible [
 

--- a/src/MethodProxies/MpHandler.class.st
+++ b/src/MethodProxies/MpHandler.class.st
@@ -15,9 +15,14 @@ Class {
 }
 
 { #category : #evaluating }
+MpHandler >> aboutToReturnWithReceiver: receiver arguments: arguments [
+
+	self afterMethod
+]
+
+{ #category : #evaluating }
 MpHandler >> afterExecutionWithReceiver: anObject arguments: anArrayOfObjects returnValue: aReturnValue [
 
-	self afterMethod.
 	^ aReturnValue
 ]
 

--- a/src/MethodProxies/MpMethodProxy.class.st
+++ b/src/MethodProxies/MpMethodProxy.class.st
@@ -291,24 +291,32 @@ MpMethodProxy >> valueWithReceiver: receiver arguments: arguments [
 
 	<methodProxyCannotWrap>
 	| result |
-	
 	"Hooking into user methods to define before actions.
 	Before actions are not instrumented."
 	handler beforeExecutionWithReceiver: receiver arguments: arguments.
-	
+
 	"Purposely do not use a non-local return.
 	Otherwise the non-local return logic would be instrumented and this could end in infinite loops"
 	[
-		IsActiveInExecutionStack := false.
-		result := self receiver: receiver withArgs: arguments executeMethod: proxifiedMethod.
-		
-		"Eagerly set it to true to avoid instrumenting all messages done during the ensure"
-		IsActiveInExecutionStack := true.
-	] methodProxyEnsure: MpMethodProxyActivator new.
+	IsActiveInExecutionStack := false.
+	result := self
+		          receiver: receiver
+		          withArgs: arguments
+		          executeMethod: proxifiedMethod.
+
+	"Eagerly set it to true to avoid instrumenting all messages done during the ensure"
+	IsActiveInExecutionStack := true ] methodProxyEnsure:
+		(MpMethodProxyActivator
+			 newWithHandler: handler
+			 receiver: receiver
+			 arguments: arguments).
 
 	"Hooking into user methods to define after actions.
 	After actions are not instrumented."
-	^ handler afterExecutionWithReceiver: receiver arguments: arguments returnValue: result
+	^ handler
+		  afterExecutionWithReceiver: receiver
+		  arguments: arguments
+		  returnValue: result
 ]
 
 { #category : #accessing }

--- a/src/MethodProxies/MpMethodProxyActivator.class.st
+++ b/src/MethodProxies/MpMethodProxyActivator.class.st
@@ -1,15 +1,69 @@
 Class {
 	#name : #MpMethodProxyActivator,
 	#superclass : #Object,
+	#instVars : [
+		'receiver',
+		'arguments',
+		'handler'
+	],
 	#pools : [
 		'MpMethodProxyPool'
 	],
 	#category : #MethodProxies
 }
 
+{ #category : #'instance creation' }
+MpMethodProxyActivator class >> newWithHandler: aHandler receiver: receiver arguments: arguments [
+
+	^ self new
+		  handler: aHandler;
+		  receiver: receiver;
+		  arguments: arguments;
+		  yourself
+]
+
 { #category : #accessing }
+MpMethodProxyActivator >> arguments [
+
+	^ arguments
+]
+
+{ #category : #accessing }
+MpMethodProxyActivator >> arguments: anObject [
+
+	arguments := anObject
+]
+
+{ #category : #accessing }
+MpMethodProxyActivator >> handler [
+
+	^ handler
+]
+
+{ #category : #accessing }
+MpMethodProxyActivator >> handler: anObject [
+
+	handler := anObject
+]
+
+{ #category : #accessing }
+MpMethodProxyActivator >> receiver [
+
+	^ receiver
+]
+
+{ #category : #accessing }
+MpMethodProxyActivator >> receiver: anObject [
+
+	receiver := anObject
+]
+
+{ #category : #evaluating }
 MpMethodProxyActivator >> value [
 
 	<methodProxyCannotWrap>
-	IsActiveInExecutionStack := true
+	IsActiveInExecutionStack := true.
+	^ handler
+		  aboutToReturnWithReceiver: receiver
+		  arguments: arguments
 ]


### PR DESCRIPTION
Make method proxies announce to the handler when their method is being unwound.

Right now, when a non local return or an exception unwinds the stack, the proxies in the middle do not have the `after` activated. Fix that adding a new hook.