### PR TITLE
Disable code coverage that interfere with proxies

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -5,10 +5,5 @@ SmalltalkCISpec {
       #directory : 'src',
       #platforms : [ #pharo ]
     }
-  ],
-  #testing : {
-    #coverage : {
-      #packages : [ 'MethodProxies' ]
-    }
-  }
+  ]
 }


### PR DESCRIPTION
As found in https://github.com/pharo-contributions/MethodProxies/pull/10

Code coverage uses proxies and interferes with some of our tests.
Disable it for now.