### PR TITLE
Fixed temp vars indeces and refactor

### DIFF
--- a/src/MethodProxies-Tests/MpArgumentListTestHandler.class.st
+++ b/src/MethodProxies-Tests/MpArgumentListTestHandler.class.st
@@ -3,11 +3,18 @@ Class {
 	#superclass : 'MpHandler',
 	#instVars : [
 		'beforeArgs',
-		'afterArgs'
+		'afterArgs',
+		'unwound'
 	],
 	#category : 'MethodProxies-Tests',
 	#package : 'MethodProxies-Tests'
 }
+
+{ #category : 'evaluating' }
+MpArgumentListTestHandler >> aboutToReturnWithReceiver: receiver arguments: arguments [
+
+	unwound := true
+]
 
 { #category : 'accessing' }
 MpArgumentListTestHandler >> afterArgs [
@@ -32,4 +39,16 @@ MpArgumentListTestHandler >> beforeArgs [
 MpArgumentListTestHandler >> beforeExecutionWithReceiver: anObject arguments: anArrayOfObjects [
 
 	beforeArgs := anArrayOfObjects
+]
+
+{ #category : 'accessing' }
+MpArgumentListTestHandler >> unwound [
+
+	^ unwound
+]
+
+{ #category : 'accessing' }
+MpArgumentListTestHandler >> unwound: anObject [
+
+	unwound := anObject
 ]

--- a/src/MethodProxies-Tests/MpClassA.class.st
+++ b/src/MethodProxies-Tests/MpClassA.class.st
@@ -57,6 +57,12 @@ MpClassA >> methodWithArgumentOne: anInteger argumentTwo: anInteger2 [
 ]
 
 { #category : 'debugging' }
+MpClassA >> methodWithArgumentOne: anInteger argumentTwo: anInteger2 argThree: arg3 [
+
+	1 error
+]
+
+{ #category : 'debugging' }
 MpClassA >> methodWithException [
 
 	1/0
@@ -66,6 +72,12 @@ MpClassA >> methodWithException [
 MpClassA >> methodWithNonLocalReturn [
 
 	self methodAcceptingABlock: [ ^ self ]
+]
+
+{ #category : 'debugging' }
+MpClassA >> methodWithNonResumableError [
+
+	1 error
 ]
 
 { #category : 'debugging' }

--- a/src/MethodProxies-Tests/MpMethodProxyTest.class.st
+++ b/src/MethodProxies-Tests/MpMethodProxyTest.class.st
@@ -31,6 +31,20 @@ MpMethodProxyTest >> handlerClass [
 ]
 
 { #category : 'tests - safety' }
+MpMethodProxyTest >> testAfterMethodGetsExecutedBesidesOfExceptioon [
+
+	| mp handler |
+	mp := MpMethodProxy
+		      onMethod: MpClassA >> #methodWithNonResumableError
+		      handler: (handler := MpAfterCounterHandler new).
+
+	self installMethodProxy: mp.
+
+	self should: [ MpClassA new methodWithNonResumableError ] raise: Error.
+	self assert: handler count equals: 1
+]
+
+{ #category : 'tests - safety' }
 MpMethodProxyTest >> testArgumentListIsSent [
 
 	| mp handler |
@@ -48,6 +62,35 @@ MpMethodProxyTest >> testArgumentListIsSent [
 	"Test after"
 	self assert: handler afterArgs size equals: 1.
 	self assert: handler afterArgs first equals: 111.
+]
+
+{ #category : 'tests - safety' }
+MpMethodProxyTest >> testArgumentListIsSentSizeThreeWithException [
+
+	| mp handler semaphore p |
+	mp := MpMethodProxy
+		      onMethod: MpClassA >> #methodWithArgumentOne:argumentTwo:argThree:
+		      handler: (handler := MpArgumentListTestHandler new).
+
+	self installMethodProxy: mp.
+
+	semaphore := Semaphore new.
+	p := [
+		     [ MpClassA new methodWithArgumentOne: 22 argumentTwo: 33 argThree: 3 ]
+			     on: Error
+			     do: [ semaphore wait ] ] forkAt: Processor activePriority + 1.
+
+	p terminate.
+
+	mp uninstall.
+
+	"Test before"
+	self assert: handler beforeArgs size equals: 3.
+	self assert: handler beforeArgs first equals: 22.
+	self assert: handler beforeArgs second equals: 33.
+	self assert: handler beforeArgs third equals: 3.
+	
+	self assert: handler unwound
 ]
 
 { #category : 'tests - safety' }
@@ -233,8 +276,10 @@ MpMethodProxyTest >> testCanWrapValueWithException [
 		on: Error
 		do: #yourself. "to avoid an extra block"
 
+	mp uninstall.
+
 	"#on:do: does send value too but it's optimised by default and there is no message send"
-	self assert: handler count equals: 2
+	self assert: handler count equals: 3
 ]
 
 { #category : 'tests - safety' }

--- a/src/MethodProxies/MpDeactivator.class.st
+++ b/src/MethodProxies/MpDeactivator.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : 'MpDeactivator',
+	#superclass : 'Object',
+	#instVars : [
+		'handler'
+	],
+	#classVars : [
+		'CompleteTempVariableIndex',
+		'WasMetaTempVariableIndex'
+	],
+	#category : 'MethodProxies',
+	#package : 'MethodProxies'
+}
+
+{ #category : 'class initialization' }
+MpDeactivator class >> initialize [
+
+	WasMetaTempVariableIndex := (MpMethodProxy class >> #prototypeTrap) tempNames indexOf: #wasMeta.
+	CompleteTempVariableIndex := (MpMethodProxy class >> #prototypeTrap) tempNames indexOf: #complete
+]
+
+{ #category : 'as yet unclassified' }
+MpDeactivator class >> withHandler: aMpHandler [
+
+	^ self new
+		  handler: aMpHandler;
+		  yourself
+]
+
+{ #category : 'accessing' }
+MpDeactivator >> asContextWithSender: aContext [
+	"Inner private support method for evaluation.  Do not use unless you know what you're doing."
+
+	^(Context newForMethod: (MpDeactivator >> #value))
+		setSender: aContext
+		receiver: self
+		method: (MpDeactivator >> #value)
+		closure: nil
+		startpc: (MpDeactivator >> #value) initialPC;
+		privRefresh
+]
+
+{ #category : 'accessing' }
+MpDeactivator >> handler: aMpHandler [
+
+	handler := aMpHandler
+]
+
+{ #category : 'evaluating' }
+MpDeactivator >> value [
+	
+	"Execution handler for the slow path. An exception or a non local return happened during proxy execution"
+	| wasMeta trapContext |
+	"Jump to the meta level (to avoid meta-recursions) to observe if the handler was in a meta level, marked by the wasMeta flag.
+			During the meta-jump call the handler to tell there was an unwind."
+	thisProcess shiftLevelUp.
+	trapContext := thisContext.
+	[ trapContext := trapContext findNextUnwindContextUpTo: nil ] doWhileFalse: [
+		trapContext method hasPragmaNamed: #trap ].
+
+	wasMeta := trapContext tempAt: trapContext method numArgs + WasMetaTempVariableIndex.
+	handler aboutToReturnWithReceiver: trapContext receiver arguments: trapContext arguments.
+
+	thisProcess shiftLevelDown.
+	
+	"If the handler was in a meta-state (i.e., the exception or non-local return happened in the handler),
+	shift it back to the base level before returning.
+	Otherwise, we were already in the base level and we need to do nothing!"
+	wasMeta ifTrue: [ thisProcess shiftLevelDown ].
+
+	"Mark execution as complete to avoid double execution of the handler."
+	trapContext tempAt: trapContext method numArgs + CompleteTempVariableIndex put: true
+]

--- a/src/MethodProxies/MpMethodProxy.class.st
+++ b/src/MethodProxies/MpMethodProxy.class.st
@@ -1286,30 +1286,7 @@ MpMethodProxy >> install [
 		(proxifiedMethod hasPragmaNamed: #noInstrumentation) ifTrue: [
 			^ MpCannotInstall signalWith: self ].
 
-		slowdeactivator := [
-			"Execution handler for the slow path. An exception or a non local return happened during proxy execution"
-			| wasMeta trapContext |
-			"Jump to the meta level (to avoid meta-recursions) to observe if the handler was in a meta level, marked by the wasMeta flag.
-			During the meta-jump call the handler to tell there was an unwind."
-			thisProcess shiftLevelUp.
-			trapContext := thisContext.
-			[ trapContext := trapContext findNextUnwindContextUpTo: nil ]
-				doWhileFalse: [ trapContext method hasPragmaNamed: #trap ].
-			
-			wasMeta := trapContext tempAt: trapContext method numArgs + 5.
-			handler
-				aboutToReturnWithReceiver: trapContext receiver
-				arguments: trapContext arguments.
-
-			thisProcess shiftLevelDown.
-
-			"If the handler was in a meta-state (i.e., the exception or non-local return happened in the handler), shift it back to the base level before returning.
-			Otherwise, we were already in the base level and we need to do nothing!"
-			wasMeta ifTrue: [ thisProcess shiftLevelDown ].
-			
-			"Mark execution as complete to avoid double execution of the handler."
-			trapContext tempAt: 2 put: true "complete temp var".
-		 ].
+		slowdeactivator := MpDeactivator withHandler: handler.
 
 		newTrap := self prototypeTrapMethod copy.
 		trapSelector := newTrap selector.

--- a/src/MethodProxiesExamples/MpAllocationProfilerHandler.class.st
+++ b/src/MethodProxiesExamples/MpAllocationProfilerHandler.class.st
@@ -18,16 +18,17 @@ p3 install.
 ```
 "
 Class {
-	#name : #MpAllocationProfilerHandler,
-	#superclass : #MpHandler,
+	#name : 'MpAllocationProfilerHandler',
+	#superclass : 'MpHandler',
 	#instVars : [
 		'allocations',
 		'transformationBlock'
 	],
-	#category : #MethodProxiesExamples
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MpAllocationProfilerHandler >> afterExecutionWithReceiver: receiver arguments: arguments returnValue: returnValue [ 
 
 	| allocationsPerClass transformedContext |
@@ -37,12 +38,12 @@ MpAllocationProfilerHandler >> afterExecutionWithReceiver: receiver arguments: a
 	^ returnValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpAllocationProfilerHandler >> allocations [
 	^ allocations
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpAllocationProfilerHandler >> captureCallingContext [
 
 	| runWithInContext |
@@ -56,20 +57,20 @@ MpAllocationProfilerHandler >> captureCallingContext [
 	^ runWithInContext ifNotNil: [ runWithInContext sender ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpAllocationProfilerHandler >> contextTransformationBlock: aBlock [
 
 	transformationBlock := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MpAllocationProfilerHandler >> initialize [
 
 	super initialize.
 	allocations := Dictionary new.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 MpAllocationProfilerHandler >> transformContext: aContext [
 
 	^ transformationBlock 

--- a/src/MethodProxiesExamples/MpCalledHandler.class.st
+++ b/src/MethodProxiesExamples/MpCalledHandler.class.st
@@ -2,33 +2,34 @@
 I'm an example handler that reports if the spyied method has been executed
 "
 Class {
-	#name : #MpCalledHandler,
-	#superclass : #MpHandler,
+	#name : 'MpCalledHandler',
+	#superclass : 'MpHandler',
 	#instVars : [
 		'called'
 	],
-	#category : #MethodProxiesExamples
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpCalledHandler >> beforeMethod [
 
 	called := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpCalledHandler >> called [
 
 	^ called
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpCalledHandler >> called: aBoolean [
 
 	called := aBoolean
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MpCalledHandler >> initialize [
 
 	super initialize.

--- a/src/MethodProxiesExamples/MpCountingHandler.class.st
+++ b/src/MethodProxiesExamples/MpCountingHandler.class.st
@@ -2,33 +2,34 @@
 I'm an example handler that counts all the times a method has been invoked
 "
 Class {
-	#name : #MpCountingHandler,
-	#superclass : #MpHandler,
+	#name : 'MpCountingHandler',
+	#superclass : 'MpHandler',
 	#instVars : [
 		'count'
 	],
-	#category : #MethodProxiesExamples
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpCountingHandler >> beforeMethod [
 
 	self count: self count + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpCountingHandler >> count [
 
 	^ count
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpCountingHandler >> count: anInteger [
 
 	count := anInteger
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MpCountingHandler >> initialize [
 
 	super initialize.

--- a/src/MethodProxiesExamples/MpCountingHandlerWithReceiver.class.st
+++ b/src/MethodProxiesExamples/MpCountingHandlerWithReceiver.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : 'MpCountingHandlerWithReceiver',
+	#superclass : 'MpCountingHandler',
+	#instVars : [
+		'rs'
+	],
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
+}
+
+{ #category : 'evaluating' }
+MpCountingHandlerWithReceiver >> beforeExecutionWithReceiver: anObject arguments: args [
+
+	rs add: anObject
+]
+
+{ #category : 'initialization' }
+MpCountingHandlerWithReceiver >> initialize [
+
+	super initialize.
+	rs := OrderedCollection new
+]

--- a/src/MethodProxiesExamples/MpFailingBeforeHandler.class.st
+++ b/src/MethodProxiesExamples/MpFailingBeforeHandler.class.st
@@ -3,12 +3,13 @@ I'm an example handler for testing purposes that fails on before.
 I'm used to check that the infrastructure does not collapse when a handler fails
 "
 Class {
-	#name : #MpFailingBeforeHandler,
-	#superclass : #MpHandler,
-	#category : #MethodProxiesExamples
+	#name : 'MpFailingBeforeHandler',
+	#superclass : 'MpHandler',
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpFailingBeforeHandler >> beforeMethod [
 
 	self error: 'error during instrumentation'

--- a/src/MethodProxiesExamples/MpMockMethodProxyHandler.class.st
+++ b/src/MethodProxiesExamples/MpMockMethodProxyHandler.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #MpMockMethodProxyHandler,
-	#superclass : #MpHandler,
-	#category : #MethodProxiesExamples
+	#name : 'MpMockMethodProxyHandler',
+	#superclass : 'MpHandler',
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpMockMethodProxyHandler >> afterExecutionWithReceiver: receiver arguments: arguments returnValue: returnValue [
 
 	^ 'trapped [', returnValue asString, ']'

--- a/src/MethodProxiesExamples/MpProfilingHandler.class.st
+++ b/src/MethodProxiesExamples/MpProfilingHandler.class.st
@@ -21,16 +21,17 @@ proxies collect: #handler
 ```
 "
 Class {
-	#name : #MpProfilingHandler,
-	#superclass : #MpHandler,
+	#name : 'MpProfilingHandler',
+	#superclass : 'MpHandler',
 	#instVars : [
 		'count',
 		'wrappedMethod'
 	],
-	#category : #MethodProxiesExamples
+	#category : 'MethodProxiesExamples',
+	#package : 'MethodProxiesExamples'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpProfilingHandler >> beforeMethod [
 
 	self count: self count + 1.
@@ -41,26 +42,26 @@ MpProfilingHandler >> beforeMethod [
 		thenDo: [ :potentialSelector | self instrumentImplementorsOf: potentialSelector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpProfilingHandler >> count [
 
 	^ count
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpProfilingHandler >> count: anInteger [
 
 	count := anInteger
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MpProfilingHandler >> initialize [
 
 	super initialize.
 	count := 0.
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpProfilingHandler >> instrumentImplementorsOf: potentialSelector [
 
 	| newProxy |
@@ -75,12 +76,12 @@ MpProfilingHandler >> instrumentImplementorsOf: potentialSelector [
 	]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MpProfilingHandler >> proxifiedMethod [
 	^ wrappedMethod
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MpProfilingHandler >> wrappedMethod: aMethod [
 	wrappedMethod := aMethod
 ]

--- a/src/MethodProxiesExamples/package.st
+++ b/src/MethodProxiesExamples/package.st
@@ -1,1 +1,1 @@
-Package { #name : #MethodProxiesExamples }
+Package { #name : 'MethodProxiesExamples' }


### PR DESCRIPTION
Done with @guillep 

- The deactivator is now an object and not a block. This is to have a cleaner approach and to NOT send value when the deactivator is invoked.
- Now obtaining the temp variables in the deactivator by index and not by name. The indeces are stored in class variables for better understanding of the code.
- Added tests to tests that the deactivator not to send value and that the after is executed besided the exception.