### PR TITLE
Can handle method

### DIFF
--- a/src/MethodProxies-Tests/MpHandlerTest.class.st
+++ b/src/MethodProxies-Tests/MpHandlerTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MpHandlerTest',
+	#superclass : 'TestCase',
+	#category : 'MethodProxies-Tests',
+	#package : 'MethodProxies-Tests'
+}
+
+{ #category : 'tests' }
+MpHandlerTest >> testCanHandleMethodWithArity [
+	
+	self assert: (MpHandler new canHandle: 5).
+	self deny: (MpHandler new canHandle: 6)
+]

--- a/src/MethodProxies/MpHandler.class.st
+++ b/src/MethodProxies/MpHandler.class.st
@@ -152,6 +152,8 @@ MpHandler >> insteadExecutionWithReceiver: anObject with: arg1 with: arg2 with: 
 MpHandler >> overridesAfterMethodFor: anInteger [
 
 	| argKeywords |
+	
+	anInteger > 5 ifTrue: [ ^ false ].
 	argKeywords := '' join: ((1 to: anInteger) collect: [ :i | 'with:' ]).
 
 	^ (self class lookupSelector:
@@ -170,6 +172,8 @@ MpHandler >> overridesBeforeMethod [
 MpHandler >> overridesBeforeMethodFor: anInteger [
 
 	| argKeywords |
+	
+	anInteger > 5 ifTrue: [ ^ false ].
 	argKeywords := '' join: ((1 to: anInteger) collect: [ :i | 'with:' ]).
 
 	^ (self class lookupSelector:
@@ -181,6 +185,8 @@ MpHandler >> overridesBeforeMethodFor: anInteger [
 MpHandler >> overridesInsteadMethodFor: anInteger [
 
 	| argKeywords |
+	
+	anInteger > 5 ifTrue: [ ^ false ].
 	argKeywords := '' join: ((1 to: anInteger) collect: [ :i | 'with:' ]).
 
 	^ (self class lookupSelector:

--- a/src/MethodProxies/MpHandler.class.st
+++ b/src/MethodProxies/MpHandler.class.st
@@ -114,6 +114,12 @@ MpHandler >> beforeMethod [
     
 ]
 
+{ #category : 'as yet unclassified' }
+MpHandler >> canHandle: arity [
+
+	^ arity < 6
+]
+
 { #category : 'evaluating' }
 MpHandler >> insteadExecutionWithReceiver: anObject [
 	^ self insteadExecutionWithReceiver: anObject arguments: {}
@@ -149,12 +155,12 @@ MpHandler >> insteadExecutionWithReceiver: anObject with: arg1 with: arg2 with: 
 ]
 
 { #category : 'as yet unclassified' }
-MpHandler >> overridesAfterMethodFor: anInteger [
+MpHandler >> overridesAfterMethodFor: arity [
 
 	| argKeywords |
 	
-	anInteger > 5 ifTrue: [ ^ false ].
-	argKeywords := '' join: ((1 to: anInteger) collect: [ :i | 'with:' ]).
+	(self canHandle: arity) ifFalse: [ ^ false ].
+	argKeywords := '' join: ((1 to: arity) collect: [ :i | 'with:' ]).
 
 	^ (self class lookupSelector:
 		   (#afterExecutionWithReceiver: , argKeywords, 'returnValue:') asSymbol)
@@ -169,12 +175,12 @@ MpHandler >> overridesBeforeMethod [
 ]
 
 { #category : 'as yet unclassified' }
-MpHandler >> overridesBeforeMethodFor: anInteger [
+MpHandler >> overridesBeforeMethodFor: arity [
 
 	| argKeywords |
 	
-	anInteger > 5 ifTrue: [ ^ false ].
-	argKeywords := '' join: ((1 to: anInteger) collect: [ :i | 'with:' ]).
+	(self canHandle: arity) ifFalse: [ ^ false ].
+	argKeywords := '' join: ((1 to: arity) collect: [ :i | 'with:' ]).
 
 	^ (self class lookupSelector:
 		   (#beforeExecutionWithReceiver: , argKeywords) asSymbol)
@@ -182,12 +188,12 @@ MpHandler >> overridesBeforeMethodFor: anInteger [
 ]
 
 { #category : 'as yet unclassified' }
-MpHandler >> overridesInsteadMethodFor: anInteger [
+MpHandler >> overridesInsteadMethodFor: arity [
 
 	| argKeywords |
 	
-	anInteger > 5 ifTrue: [ ^ false ].
-	argKeywords := '' join: ((1 to: anInteger) collect: [ :i | 'with:' ]).
+	(self canHandle: arity) ifFalse: [ ^ false ].
+	argKeywords := '' join: ((1 to: arity) collect: [ :i | 'with:' ]).
 
 	^ (self class lookupSelector:
 		   (#insteadExecutionWithReceiver: , argKeywords) asSymbol)


### PR DESCRIPTION

We added this check with @guillep to prevent overriding methods with more than 5 arguments.

I added a silly test case just to trigger an error in case we update the supported arity.